### PR TITLE
Daemonize start

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,35 +1,20 @@
-:: These are basically explicit copies of the go get stuff in the makefile
-:: The linux version is source of truth.
-go get -u gopkg.in/redis.v3
-go get -u github.com/nats-io/nats
-go get -u github.com/lib/pq
-go get -u github.com/connectordb/duck
-go get -u github.com/jmoiron/sqlx
-go get -u github.com/xeipuuv/gojsonschema
-go get -u gopkg.in/vmihailenco/msgpack.v2
-go get -u gopkg.in/fsnotify.v1
-go get -u github.com/kardianos/osext
-go get -u github.com/nu7hatch/gouuid
-go get -u github.com/gorilla/mux github.com/gorilla/context github.com/gorilla/sessions github.com/gorilla/websocket
-go get -u github.com/Sirupsen/logrus
-go get -u github.com/josephlewis42/multicache
-go get -u github.com/connectordb/njson
-go get -u github.com/codegangsta/cli
-go get -u github.com/tdewolff/minify
-go get -u golang.org/x/crypto/bcrypt
-go get -u github.com/dkumor/acmewrapper
-go get -u github.com/gernest/hot
-go get -u github.com/russross/blackfriday
-go get -u github.com/microcosm-cc/bluemonday
-go get -u github.com/stretchr/testify
-go get -u github.com/connectordb/pipescript
+@echo off
+:: This is JUST the build command. You must
+:: run dependencies.bat first to set up the folders
 
+:: https://stackoverflow.com/questions/6359820/how-to-set-commands-output-as-a-variable-in-a-batch-file
+FOR /F "tokens=* USEBACKQ" %%F IN (`git rev-parse HEAD`) DO (
+SET gitsha=%%F
+)
+ECHO git sha: %gitsha%
 
-if not exist "bin" mkdir "bin"
-robocopy /s "./src/dbsetup/config" "./bin/config"
+:: https://stackoverflow.com/questions/203090/how-to-get-current-datetime-on-windows-command-line-in-a-suitable-format-for-us
+For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
+For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
+SET curtime=%mydate%
+ECHO build date: %curtime%
+:: TODO: The curtime command should be %mydate%_%mytime%, but mytime seems to have a space, which makes go unhappy
+:: Also... should make it utc.
 
-go build -o bin/connectordb.exe src/main.go
+go build -o bin/connectordb.exe  -ldflags "-X commands.BuildStamp=%curtime% -X commands.GitHash=%gitsha%" src/main.go 
 
-echo Now you must put all dependent executables in bin/dep
-echo you must also copy the site/www directory to bin
-echo Finally you must compile the frontend and put it in bin/app

--- a/dependencies.bat
+++ b/dependencies.bat
@@ -1,0 +1,29 @@
+:: These are basically explicit copies of the go get stuff in the makefile
+:: The linux version is source of truth.
+go get -u gopkg.in/redis.v3
+go get -u github.com/nats-io/nats
+go get -u github.com/lib/pq
+go get -u github.com/connectordb/duck
+go get -u github.com/jmoiron/sqlx
+go get -u github.com/xeipuuv/gojsonschema
+go get -u gopkg.in/vmihailenco/msgpack.v2
+go get -u gopkg.in/fsnotify.v1
+go get -u github.com/kardianos/osext
+go get -u github.com/nu7hatch/gouuid
+go get -u github.com/gorilla/mux github.com/gorilla/context github.com/gorilla/sessions github.com/gorilla/websocket
+go get -u github.com/Sirupsen/logrus
+go get -u github.com/josephlewis42/multicache
+go get -u github.com/connectordb/njson
+go get -u github.com/spf13/cobra
+go get -u github.com/tdewolff/minify
+go get -u golang.org/x/crypto/bcrypt
+go get -u github.com/dkumor/acmewrapper
+go get -u github.com/gernest/hot
+go get -u github.com/russross/blackfriday
+go get -u github.com/microcosm-cc/bluemonday
+go get -u github.com/stretchr/testify
+go get -u github.com/connectordb/pipescript
+
+
+if not exist "bin" mkdir "bin"
+robocopy /s "./src/dbsetup/config" "./bin/config"

--- a/runtests.sh
+++ b/runtests.sh
@@ -149,7 +149,6 @@ echo "==================================================="
 nosetests --with-coverage --cover-package=connectordb -s --nologcapture connectordb_python/connectordb_test.py connectordb_python/query_test.py
 test_status=$?
 
-./bin/connectordb -l=DEBUG stop $DBDIR
 stop
 
 check_pids

--- a/runtests.sh
+++ b/runtests.sh
@@ -81,9 +81,9 @@ force_stop () {
 
 start () {
 	echo "==================================================="
-	echo "Doing Start"
+	echo "Doing Backend Start"
 	echo "==================================================="
-	./bin/connectordb start $DBDIR
+	./bin/connectordb start $DBDIR --backend
 }
 
 create () {
@@ -125,7 +125,7 @@ if [ "$test_status" -ne 0 ]; then
 fi
 
 #go test --timeout 15s -p=1 -bench . connectordb/...
-test_status=$?
+#test_status=$?
 stop
 check_pids
 
@@ -135,14 +135,13 @@ fi
 
 
 create
-start
+
 #Now test the python stuff, while rebuilding the db to make sure that
 #the go tests didn't invalidate the db
 echo "==================================================="
 echo "Starting Server"
 echo "==================================================="
-./bin/connectordb -l=DEBUG run $DBDIR &
-cdb_server=$!
+./bin/connectordb -l=DEBUG start $DBDIR
 
 echo "==================================================="
 echo "Starting API Tests"
@@ -150,7 +149,7 @@ echo "==================================================="
 nosetests --with-coverage --cover-package=connectordb -s --nologcapture connectordb_python/connectordb_test.py connectordb_python/query_test.py
 test_status=$?
 
-kill $cdb_server
+./bin/connectordb -l=DEBUG stop $DBDIR
 stop
 
 check_pids

--- a/src/commands/create.go
+++ b/src/commands/create.go
@@ -56,6 +56,9 @@ configuration.`,
 			}
 		}
 
+		// set up logging based on create config (this allows debug msgs in testing config)
+		setLogging(cfg)
+
 		return dbsetup.Create(cfg)
 
 	},

--- a/src/commands/root.go
+++ b/src/commands/root.go
@@ -101,7 +101,7 @@ func setLogging(c *config.Configuration) (err error) {
 
 func init() {
 
-	RootCmd.PersistentFlags().StringVar(&logfile, "log", "", "The file to which log output is written")
+	RootCmd.PersistentFlags().StringVar(&logfile, "logfile", "", "The file to which log output is written")
 	RootCmd.PersistentFlags().StringVarP(&loglevel, "loglevel", "l", "", "The types of messages to show (debug,info,warn,error)")
 	RootCmd.PersistentFlags().StringVar(&cpuprofile, "cpuprof", "", "File to which a cpu profile of ConnectorDB will be written")
 

--- a/src/commands/root.go
+++ b/src/commands/root.go
@@ -37,9 +37,7 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "connectordb",
 	Short: "ConnectorDB is a repository for your quantified-self and IoT data",
-	Long: `ConnectorDB is a quick and powerful database
-built for interacting with your IoT devices and for
-storing your quantified-self data.`,
+	Long:  `ConnectorDB is a powerful database built for interacting with your IoT devices and for storing your quantified-self data.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if version {

--- a/src/commands/run.go
+++ b/src/commands/run.go
@@ -38,6 +38,8 @@ ConnectorDB API and web app.`,
 			return err
 		}
 
+		setLogging(cfg)
+
 		// Override the flag-based options if they are set
 		// WARNING: These overrides will NOT hold if the config file is reloaded
 		// during runtime.

--- a/src/commands/run.go
+++ b/src/commands/run.go
@@ -73,6 +73,8 @@ ConnectorDB API and web app.`,
 		// Print out the configuration as we understand it
 		log.Debug(cfg.String())
 
+		// The configuration is loaded globally. We now start the server, which
+		// will use the config for its options.
 		return server.RunServer()
 
 	},

--- a/src/commands/shell.go
+++ b/src/commands/shell.go
@@ -24,6 +24,8 @@ ConnectorDB database from the command line.`,
 			return err
 		}
 
+		setLogging(cfg)
+
 		// Open the ConnectorDB database
 		db, err := connectordb.Open(cfg.Options())
 		if err != nil {

--- a/src/commands/start.go
+++ b/src/commands/start.go
@@ -14,14 +14,25 @@ import (
 var (
 	// whether to force a start even if pid files exist
 	force bool
+
+	// The run matrix - which services to start
+	runpostgres bool
+	rungnatsd   bool
+	runredis    bool
+	runfrontend bool
+	runbackend  bool
 )
 
 // StartCmd starts the background servers
 var StartCmd = &cobra.Command{
 	Use:   "start [config file path or database directory]",
-	Short: "Starts ConnectorDB's backend databases",
-	Long: `ConnectorDB uses postgres, redis, and gnatsd in the background.
-This command starts these services, so that they run in the background.`,
+	Short: "Starts ConnectorDB and its backend services as a daemon",
+	Long: `ConnectorDB uses postgres, redis, and gnatsd in the background, and runs its own
+frontend server using these services. The start command allows you to start
+all of the services including the frontend as a daemon. You can also use the start command
+with the --backend flag to start only the background servers, and can use connectordb run to
+run the frontend server in the foreground. Don't forget to shut down the backend with
+connectordb stop.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return ErrConfig
@@ -42,7 +53,31 @@ This command starts these services, so that they run in the background.`,
 			os.Remove(filepath.Join(args[0], "connectordb.pid"))
 		}
 
-		err := dbsetup.Start(args[0])
+		opt := &dbsetup.Options{
+			DatabaseDirectory: args[0],
+			RedisEnabled:      true,
+			GnatsdEnabled:     true,
+			PostgresEnabled:   true,
+			FrontendEnabled:   true,
+		}
+
+		// If any of the flags is given, we do manual start
+		if runredis || rungnatsd || runpostgres || runfrontend || runbackend {
+			if runbackend {
+				runredis = true
+				rungnatsd = true
+				runpostgres = true
+			}
+
+			log.Infof("Starting: redis=%t sql=%t nats=%t frontend=%t", runredis, rungnatsd, runpostgres, runfrontend)
+
+			opt.RedisEnabled = runredis
+			opt.GnatsdEnabled = rungnatsd
+			opt.PostgresEnabled = runpostgres
+			opt.FrontendEnabled = runfrontend
+		}
+
+		err := dbsetup.Start(opt)
 
 		if err == dbsetup.ErrAlreadyRunning {
 			log.Error(err.Error())
@@ -54,5 +89,12 @@ This command starts these services, so that they run in the background.`,
 
 func init() {
 	StartCmd.Flags().BoolVar(&force, "force", false, "forces start of the database even if connectordb.pid exists")
+
+	StartCmd.Flags().BoolVar(&runredis, "redis", false, "start the backend redis server (if no flags given, all started)")
+	StartCmd.Flags().BoolVar(&rungnatsd, "nats", false, "start the backend nats server (if no flags given, all started)")
+	StartCmd.Flags().BoolVar(&runpostgres, "sql", false, "start the backend sql server (postgres) (if no flags given, all started)")
+	StartCmd.Flags().BoolVar(&runfrontend, "frontend", false, "start the ConnectorDB server (same as connectordb run but as daemon) (if no flags given, all started)")
+	StartCmd.Flags().BoolVar(&runbackend, "backend", false, "start only backend servers - same as --redis --nats --sql (if no flags given, all started)")
+
 	RootCmd.AddCommand(StartCmd)
 }

--- a/src/commands/start.go
+++ b/src/commands/start.go
@@ -26,7 +26,7 @@ var (
 // StartCmd starts the background servers
 var StartCmd = &cobra.Command{
 	Use:   "start [config file path or database directory]",
-	Short: "Starts ConnectorDB and its backend services as a daemon",
+	Short: "Starts ConnectorDB and its backend services as daemons",
 	Long: `ConnectorDB uses postgres, redis, and gnatsd in the background, and runs its own
 frontend server using these services. The start command allows you to start
 all of the services including the frontend as a daemon. You can also use the start command
@@ -45,7 +45,7 @@ connectordb stop.`,
 			return errors.New("Could not find the given directory")
 		}
 
-		log.Info("Starting Database")
+		log.Info("Starting ConnectorDB")
 
 		//force removes the pid file
 		if force {
@@ -59,6 +59,8 @@ connectordb stop.`,
 			GnatsdEnabled:     true,
 			PostgresEnabled:   true,
 			FrontendEnabled:   true,
+			FrontendFlags:     setRunFlags(),
+			FrontendPort:      port, // The port should be 0 by default. This is so waiting for port Open doesn't fail
 		}
 
 		// If any of the flags is given, we do manual start

--- a/src/commands/stop.go
+++ b/src/commands/stop.go
@@ -29,7 +29,9 @@ These servers are started with the start command. This command stops the servers
 
 		log.Info("Stopping Database")
 
-		return dbsetup.Stop(args[0])
+		return dbsetup.Stop(&dbsetup.Options{
+			DatabaseDirectory: args[0],
+		})
 
 	},
 }

--- a/src/commands/stop.go
+++ b/src/commands/stop.go
@@ -12,9 +12,8 @@ import (
 // StopCmd stops the background servers
 var StopCmd = &cobra.Command{
 	Use:   "stop [config file path or database directory]",
-	Short: "Stops ConnectorDB's backend databases",
-	Long: `ConnectorDB uses postgres, redis, and gnatsd in the background.
-These servers are started with the start command. This command stops the servers.`,
+	Short: "Stops ConnectorDB daemons",
+	Long:  `Stops the servers started with the start command`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return ErrConfig
@@ -27,7 +26,7 @@ These servers are started with the start command. This command stops the servers
 			return errors.New("Could not find the given directory")
 		}
 
-		log.Info("Stopping Database")
+		log.Info("Stopping ConnectorDB")
 
 		return dbsetup.Stop(&dbsetup.Options{
 			DatabaseDirectory: args[0],

--- a/src/config/configuration.go
+++ b/src/config/configuration.go
@@ -74,26 +74,17 @@ type Configuration struct {
 	DeviceCacheSize int64 `json:"device_cache_size"`
 	StreamCacheSize int64 `json:"stream_cache_size"`
 
-	//These are optional - if they are set, an initial user is created on Create()
-	//They are used only when passing a Configuration object to Create()
-	InitialUser *UserMaker `json:"initial_user"`
-
 	// The prime number to use for scrambling IDs in the database.
 	// WARNING: This must be CONSTANT! It should NEVER change after creating the database
 	// http://preshing.com/20121224/how-to-generate-a-sequence-of-unique-random-integers/
 	IDScramblePrime int64 `json:"database_id_scramble_prime"`
 
 	// The default algorithm to use for hashing passwords. Options are SHA512 and bcrypt
+	// This can be changed during runtime, and the user passwords will upgrade when they log in
 	PasswordHash string `json:"password_hash"`
 
 	// The configuration options for pipescript (https://github.com/connectordb/pipescript)
 	PipeScript *psconfig.Configuration `json:"pipescript"`
-
-	// The following are exported fields that are used internally, and are not available to json.
-	// This is honestly just lazy programming on my part - I am using the config struct as a temporary variable
-	// placeholder when creating/starting a database... So technically it is part of the configuration, but it is
-	// given explicitly as part of the command line args
-	DatabaseDirectory string `json:"-"`
 }
 
 // UserMaker: Since we can't import the *actual* UserMaker from users (since that would give an import loop)

--- a/src/config/defaultconfig.go
+++ b/src/config/defaultconfig.go
@@ -50,6 +50,9 @@ func NewConfiguration() *Configuration {
 
 			Enabled: true,
 
+			LogFile:  "",
+			LogLevel: "info",
+
 			// Sets up the session cookie keys that are used
 			CookieSession: CookieSession{
 				AuthKey:       base64.StdEncoding.EncodeToString(sessionAuthKey),

--- a/src/config/frontend.go
+++ b/src/config/frontend.go
@@ -30,6 +30,10 @@ type Frontend struct {
 	// Whether or not the frontend is enabled
 	Enabled bool `json:"frontend_enabled"`
 
+	// The log file to use & the Log Level
+	LogFile  string `json:"logfile"`
+	LogLevel string `json:"loglevel"`
+
 	// The domain name of the website at which connectordb is running.
 	// This enables Connectordb to be able to output links to itself.
 	// Leave blank if domain is the same as Hostname

--- a/src/config/global.go
+++ b/src/config/global.go
@@ -76,6 +76,14 @@ func SetPath(filename string) error {
 		return c.PipeScript.Set()
 	})
 
+	// Next, we set up global logging. This is pretty convoluted,
+	// but it turns out that due to some annoyance in putting together command
+	// line logging parameters and these, logging is set up outside of this
+	// method - but we still want logging to be set when the configuration changes
+	OnChangeCallback(func(c *Configuration) error {
+		return SetLoggingFromConfig(c)
+	})
+
 	if !Get().Watch {
 		// Closing it will keep the config valid
 		globalConfiguration.Close()

--- a/src/config/logging.go
+++ b/src/config/logging.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var prevLogFile *os.File
+var prevLogFileName string
+
+// SetLogging sets the given log level and log file for the entire application.
+func SetLogging(loglevel string, logfile string) error {
+
+	// First, set up the log level
+	switch loglevel {
+	default:
+		return fmt.Errorf("Unrecognized log level %s. Must be one of debug,info,warn,error", loglevel)
+	case "INFO", "info", "":
+		log.SetLevel(log.InfoLevel)
+	case "WARN", "warn":
+		log.SetLevel(log.WarnLevel)
+	case "DEBUG", "debug":
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Setting DEBUG log level")
+	case "ERROR", "error":
+		log.SetLevel(log.ErrorLevel)
+	}
+
+	//  Next set up the log file if it is different than the current one
+	if logfile != "" && logfile != prevLogFileName {
+		log.Infof("Writing logs to %s", logfile)
+		logf, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			return fmt.Errorf("Could not open file %s: %s", logfile, err.Error())
+		}
+		log.SetFormatter(&log.JSONFormatter{})
+		log.SetOutput(logf)
+
+		// Now we close previous file if it exists
+		if prevLogFile != nil {
+			prevLogFile.Close()
+		}
+		prevLogFile = logf
+		prevLogFileName = logfile
+	} else if logfile == "" && prevLogFile != nil {
+		log.SetFormatter(&log.TextFormatter{})
+		log.SetOutput(os.Stdout)
+		prevLogFile = nil
+		prevLogFileName = ""
+	}
+	return nil
+}
+
+// SetLoggingFromConfig is a simple wrapper for SetLogging
+func SetLoggingFromConfig(c *Configuration) error {
+	return SetLogging(c.LogLevel, c.LogFile)
+}

--- a/src/config/service.go
+++ b/src/config/service.go
@@ -14,8 +14,6 @@ type Service struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 
-	//SSLPort uint16 `json:"sslport"` //The port on which to run Stunnel
-
 	Enabled bool `json:"enabled"` //Whether or not to run the service on "connectordb start"
 }
 

--- a/src/config/testconfig.go
+++ b/src/config/testconfig.go
@@ -28,13 +28,6 @@ var TestConfiguration = func() Configuration {
 		Enabled: true,
 	}
 
-	c.InitialUser = &UserMaker{
-		Name:     "test",
-		Email:    "test@localhost",
-		Password: "test",
-		Role:     "admin",
-	}
-
 	c.BatchSize = 250
 	c.ChunkSize = 1
 
@@ -43,6 +36,14 @@ var TestConfiguration = func() Configuration {
 
 	return *c
 }()
+
+// TestUser is the user generated for the testing configuration
+var TestUser = &UserMaker{
+	Name:     "test",
+	Email:    "test@localhost",
+	Password: "test",
+	Role:     "admin",
+}
 
 //TestOptions is the options of tests
 var TestOptions = TestConfiguration.Options()

--- a/src/config/testconfig.go
+++ b/src/config/testconfig.go
@@ -38,6 +38,9 @@ var TestConfiguration = func() Configuration {
 	c.BatchSize = 250
 	c.ChunkSize = 1
 
+	// The debug log level shows ALL the messages :)
+	c.LogLevel = "debug"
+
 	return *c
 }()
 

--- a/src/config/validate.go
+++ b/src/config/validate.go
@@ -104,7 +104,7 @@ func (c *Configuration) Validate() error {
 	}
 
 	// Try loading the permissions
-	p, err := permissions.Load(c.Permissions)
+	_, err := permissions.Load(c.Permissions)
 	if err != nil {
 		return err
 	}
@@ -113,13 +113,6 @@ func (c *Configuration) Validate() error {
 		c.Permissions, err = filepath.Abs(c.Permissions)
 		if err != nil {
 			return err
-		}
-	}
-
-	// Check that the initial user permissions exist if given
-	if c.InitialUser != nil && c.InitialUser.Role != "" {
-		if _, ok := p.UserRoles[c.InitialUser.Role]; !ok {
-			return fmt.Errorf("Could not find role of '%s' for the initial creation user", c.InitialUser.Role)
 		}
 	}
 

--- a/src/config/validate.go
+++ b/src/config/validate.go
@@ -18,6 +18,21 @@ import (
 // correctly.
 func (f *Frontend) Validate(c *Configuration) (err error) {
 
+	switch f.LogLevel {
+	default:
+		return fmt.Errorf("Unrecognized log level %s. Must be one of debug,info,warn,error", f.LogLevel)
+	case "", "INFO", "info", "WARN", "warn", "DEBUG", "debug", "ERROR", "error":
+		// it is valid. Do nothing
+	}
+
+	// Set the log file's absolute path
+	if f.LogFile != "" {
+		f.LogFile, err = filepath.Abs(f.LogFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Validate the TLS config
 	if err = f.TLS.Validate(); err != nil {
 		return err

--- a/src/dbsetup/allservices.go
+++ b/src/dbsetup/allservices.go
@@ -151,7 +151,7 @@ func Start(o *Options) error {
 	}
 
 	if c.Frontend.Enabled && o.FrontendEnabled {
-		f := NewFrontendService(o.DatabaseDirectory, c)
+		f := NewFrontendService(o.DatabaseDirectory, c, o)
 		if err := f.Start(); err != nil {
 			if r != nil {
 				r.Stop()
@@ -195,7 +195,7 @@ func Stop(opt *Options) error {
 
 	if c.Frontend.Enabled && o.FrontendEnabled {
 		// We close the frontend First
-		errF = NewFrontendService(o.DatabaseDirectory, c).Stop()
+		errF = NewFrontendService(o.DatabaseDirectory, c, o).Stop()
 	}
 
 	if c.Redis.Enabled && o.RedisEnabled {

--- a/src/dbsetup/filetools.go
+++ b/src/dbsetup/filetools.go
@@ -162,6 +162,7 @@ func GetPostgresExecutablePath(executableName string) string {
 
 // Find a postgres utility e.g. initdb or postgres using the lame grep method, works on Ubuntu (for now)
 func findPostgresExecutableGrep(executableName string) string {
+	log.Debugf("Checking for %s by grep in /usr/lib/postgresql", executableName)
 
 	findCmd := fmt.Sprintf("find /usr/lib/postgresql/ | sort -r | grep -m 1 /bin/%v", executableName)
 
@@ -211,11 +212,10 @@ func getExecutablePath(executableName string) (string, error) {
 	}
 	log.Debugf("Checking for %s in path...", executableName)
 	// Start with which because we prefer a PATH version
-	out := findExecutableWhich(executableName)
-
+	out := trimExecutablePath(findExecutableWhich(executableName))
 	if out != "" {
 		log.Debugf("Using %s", out)
-		return trimExecutablePath(out), nil
+		return out, nil
 	}
 
 	return "", fmt.Errorf("Could not find executable %s", executableName)

--- a/src/dbsetup/frontend.go
+++ b/src/dbsetup/frontend.go
@@ -1,0 +1,59 @@
+package dbsetup
+
+import (
+	"config"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"util"
+
+	"github.com/kardianos/osext"
+)
+
+//FrontendService is a service for running the ConnectorDB frontend
+type FrontendService struct {
+	BaseService
+	c *config.Configuration
+}
+
+// The frontend doesn't need to be created.
+func (s *FrontendService) Create() error {
+	return nil
+}
+
+//Start starts the service
+func (s *FrontendService) Start() error {
+	// We just call our own executable with different options to start up frontend
+	connectordb, err := osext.Executable()
+
+	// This is the base run string
+	flags := []string{"run", s.ServiceDirectory}
+
+	// The greatest difficulty now is to figure out how to send command line options
+	// from start. For now, we just use a hack: we manually set send ALL of the command line options.
+	// This should be fixed at some point, but for now it works, so fukkit.
+	flags = append(flags, "--loglevel", s.c.LogLevel)
+	flags = append(flags, "--log", s.c.LogFile)
+
+	var pid int
+	pid, err = util.RunDaemon(err, connectordb, flags...)
+	err = util.WaitPort(s.c.Hostname, int(s.c.Port), err)
+
+	if err == nil {
+		s.Stat = StatusRunning
+	} else {
+		s.Stat = StatusError
+	}
+	if err != nil {
+		return err
+	}
+
+	// Finally, we write a pid file for frontend
+	return ioutil.WriteFile(filepath.Join(s.ServiceDirectory, "frontend.pid"), []byte(strconv.Itoa(pid)), 0666)
+
+}
+
+//NewFrontendService creates a new service for the ConnectorDB frontend
+func NewFrontendService(serviceDirectory string, c *config.Configuration) *FrontendService {
+	return &FrontendService{BaseService{serviceDirectory, "frontend", StatusNone, nil}, c}
+}

--- a/src/dbsetup/frontend.go
+++ b/src/dbsetup/frontend.go
@@ -43,7 +43,8 @@ func (s *FrontendService) Start() error {
 	if s.o.FrontendPort != 0 {
 		port = s.o.FrontendPort
 	}
-	err = util.WaitPort(s.c.Hostname, int(port), err)
+	// Windows needs to know that we're on localhost
+	err = util.WaitPort("localhost", int(port), err)
 
 	if err == nil {
 		s.Stat = StatusRunning

--- a/src/dbsetup/gnatsd.go
+++ b/src/dbsetup/gnatsd.go
@@ -21,7 +21,7 @@ func (s *GnatsdService) Start() error {
 		return err
 	}
 
-	err = util.RunDaemon(err, GetExecutablePath("gnatsd"), "-c", configfile)
+	_, err = util.RunDaemon(err, GetExecutablePath("gnatsd"), "-c", configfile)
 	err = util.WaitPort(s.S.Hostname, int(s.S.Port), err)
 
 	if err == nil {

--- a/src/dbsetup/options.go
+++ b/src/dbsetup/options.go
@@ -25,6 +25,11 @@ type Options struct {
 	RedisEnabled    bool `json:"redis_running"`
 	GnatsdEnabled   bool `json:"gnatsd_running"`
 	PostgresEnabled bool `json:"postgres_running"`
+
+	// FrontendFlags are flags to pass to the frontend when starting it.
+	// This allows using connectordb start with connectordb run's flags
+	FrontendFlags []string
+	FrontendPort  uint16 // Overload port
 }
 
 // Save saves the configuration

--- a/src/dbsetup/options.go
+++ b/src/dbsetup/options.go
@@ -1,0 +1,52 @@
+package dbsetup
+
+import (
+	"config"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// Options represents the configuration used for dbsetup. It is the source of
+// truth used when creating/starting/stopping the database
+type Options struct {
+	// The directory in which ConnectorDB is set up
+	DatabaseDirectory string `json:"database_directory"`
+
+	// Config is used for Create.
+	Config *config.Configuration `json:"config"`
+
+	//These are optional - if they are set, an initial user is created on Create()
+	//They are used only when passing a Configuration object to Create()
+	InitialUser *config.UserMaker `json:"initial_user"`
+
+	// The enabled options specify which services to set up/run
+	FrontendEnabled bool `json:"frontend_running"`
+	RedisEnabled    bool `json:"redis_running"`
+	GnatsdEnabled   bool `json:"gnatsd_running"`
+	PostgresEnabled bool `json:"postgres_running"`
+}
+
+// Save saves the configuration
+func (o *Options) Save(filename string) error {
+	b, err := json.MarshalIndent(o, "", "\t")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, b, 0666)
+}
+
+// LoadOptions loads the options from a file
+func LoadOptions(filename string) (*Options, error) {
+	file, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load setup options from '%s': %s", filename, err.Error())
+	}
+
+	o := &Options{}
+	err = json.Unmarshal(file, o)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load options from '%s': %s", filename, err.Error())
+	}
+	return o, nil
+}

--- a/src/dbsetup/postgres.go
+++ b/src/dbsetup/postgres.go
@@ -70,7 +70,7 @@ func (s *PostgresService) Start() error {
 		return err
 	}
 
-	err = util.RunDaemon(err, GetPostgresExecutablePath("postgres"), "-D", postgresDir)
+	_, err = util.RunDaemon(err, GetPostgresExecutablePath("postgres"), "-D", postgresDir)
 	err = util.WaitPort(s.S.Hostname, int(s.S.Port), err)
 
 	if err == nil {

--- a/src/dbsetup/redis.go
+++ b/src/dbsetup/redis.go
@@ -24,7 +24,7 @@ func (s *RedisService) Start() error {
 		return err
 	}
 
-	err = util.RunDaemon(err, GetExecutablePath("redis-server"), configfile)
+	_, err = util.RunDaemon(err, GetExecutablePath("redis-server"), configfile)
 	err = util.WaitPort(s.S.Hostname, int(s.S.Port), err)
 
 	if err == nil {

--- a/src/dbsetup/service.go
+++ b/src/dbsetup/service.go
@@ -6,7 +6,6 @@ package dbsetup
 
 import (
 	"config"
-	"os"
 	"runtime"
 	"syscall"
 	"util"
@@ -100,7 +99,8 @@ func (bs BaseService) Stop() error {
 	log.Debugf("%s has pid %d", bs.Name(), p.Pid)
 
 	if runtime.GOOS == "windows" {
-		p.Signal(os.Interrupt)
+		// Why does windows not have a nicer signal to stop a process?
+		p.Kill()
 	} else {
 		// On linux, sigterm is used
 		if err := p.Signal(syscall.SIGTERM); err != nil {

--- a/src/dbsetup/service.go
+++ b/src/dbsetup/service.go
@@ -6,6 +6,7 @@ package dbsetup
 
 import (
 	"config"
+	"os"
 	"runtime"
 	"syscall"
 	"util"
@@ -99,14 +100,18 @@ func (bs BaseService) Stop() error {
 	log.Debugf("%s has pid %d", bs.Name(), p.Pid)
 
 	if runtime.GOOS == "windows" {
-		p.Kill()
+		p.Signal(os.Interrupt)
 	} else {
-		// A lighter way to kill the process...
+		// On linux, sigterm is used
 		if err := p.Signal(syscall.SIGTERM); err != nil {
 			bs.Stat = StatusError
 			return err
 		}
 	}
+
+	p.Wait()
+
+	bs.Stat = StatusStopped
 
 	return nil
 }

--- a/src/server/website/authenticate.go
+++ b/src/server/website/authenticate.go
@@ -48,7 +48,7 @@ func Authenticator(www wwwtemplatebookmark, apifunc webcore.APIHandler, db *conn
 		//Access control to the website is blocked
 		//webcore.WriteAccessControlHeaders(writer, request)
 		if !webcore.IsActive && webcore.HasSession(request) {
-			WriteError(logger, writer, http.StatusServiceUnavailable, errors.New("ConnectorDB app is disabled for maintenance."), false, nil)
+			WriteError(logger, writer, http.StatusServiceUnavailable, errors.New("ConnectorDB app is disabled."), false, nil)
 			return
 		}
 

--- a/src/shell/lscxn.go
+++ b/src/shell/lscxn.go
@@ -25,9 +25,6 @@ func init() {
 		dbcxn := cfg.GetSqlConnectionString()
 		fmt.Printf("Database: %v\n", dbcxn)
 
-		streamdb := cfg.DatabaseDirectory
-		fmt.Printf("Streamdb: %v\n", streamdb)
-
 		redis := cfg.Redis.GetRedisConnectionString()
 		fmt.Printf("Redis: %v\n", redis)
 

--- a/src/util/processes.go
+++ b/src/util/processes.go
@@ -73,9 +73,9 @@ func RunCommand(err error, command string, args ...string) error {
 }
 
 //RunDaemon runs the given command as a daemon (in the background)
-func RunDaemon(err error, command string, args ...string) error {
+func RunDaemon(err error, command string, args ...string) (int, error) {
 	if err != nil {
-		return err
+		return 0, err
 	}
 	log.Debugf(cmd2Str(command, args...))
 
@@ -88,7 +88,11 @@ func RunDaemon(err error, command string, args ...string) error {
 	//I am not convinced at the moment that restarting postgres/other stuff will be a good idea
 	//especially since that is what happens when we want to kill them from another process.
 	//So, for the moment, just start the process
-	return cmd.Start()
+	err = cmd.Start()
+	if err != nil {
+		return 0, err
+	}
+	return cmd.Process.Pid, nil
 }
 
 //GetProcess gets the gven process using its process name


### PR DESCRIPTION
```bash
connectordb start mydb
```
now starts the frontend server as a daemon too. This makes it easy to run ConnectorDB in the background.

Furthermore, there are now more detailed options for running specific services.